### PR TITLE
Adding generation input

### DIFF
--- a/provider/cmd/pulumi-resource-hyperv/schema.json
+++ b/provider/cmd/pulumi-resource-hyperv/schema.json
@@ -79,6 +79,10 @@
                                                                                        "type":  "string",
                                                                                        "description":  "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps."
                                                                                    },
+                                                                        "generation":  {
+                                                                                           "type":  "integer",
+                                                                                           "description":  "Generation of the Virtual Machine. Defaults to 2."
+                                                                                       },
                                                                         "machineName":  {
                                                                                             "type":  "string",
                                                                                             "description":  "Name of the Virtual Machine"
@@ -117,6 +121,10 @@
                                                                                             "type":  "string",
                                                                                             "description":  "The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT\nand PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the\nCommand resource from previous create or update steps."
                                                                                         },
+                                                                             "generation":  {
+                                                                                                "type":  "integer",
+                                                                                                "description":  "Generation of the Virtual Machine. Defaults to 2."
+                                                                                            },
                                                                              "machineName":  {
                                                                                                  "type":  "string",
                                                                                                  "description":  "Name of the Virtual Machine"

--- a/provider/pkg/provider/machine/machine.go
+++ b/provider/pkg/provider/machine/machine.go
@@ -40,18 +40,43 @@ func (c *Machine) Annotate(a infer.Annotator) {
 	a.Describe(&c, resourceDoc)
 }
 
+// This is the type that implements the network adapter inputs.
+type NetworkAdapterInput struct {
+	Name       *string `pulumi:"name"`
+	SwitchName *string `pulumi:"switchName"`
+}
+
+type HardDriveInput struct {
+	Path               *string `pulumi:"path"`
+	ControllerType     *string `pulumi:"controllerType"`
+	ControllerNumber   *int    `pulumi:"controllerNumber"`
+	ControllerLocation *int    `pulumi:"controllerLocation"`
+}
+
 // These are the inputs (or arguments) to a Vm resource.
 type MachineInputs struct {
 	common.ResourceInputs
 	MachineName    *string `pulumi:"machineName"`
+	Generation     *int    `pulumi:"generation,optional"`
 	ProcessorCount *int    `pulumi:"processorCount,optional"`
 	MemorySize     *int    `pulumi:"memorySize,optional"`
+	// NetworkAdapters []*NetworkAdapterInput `pulumi:"networkAdapters,optional"`
+	// HardDrives      []*HardDriveInput      `pulumi:"hardDrives,optional"`
 }
 
 func (c *MachineInputs) Annotate(a infer.Annotator) {
 	a.Describe(&c.MachineName, "Name of the Virtual Machine")
 	a.Describe(&c.ProcessorCount, "Number of processors to allocate to the Virtual Machine. Defaults to 1.")
 	a.Describe(&c.MemorySize, "Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.")
+	a.Describe(&c.Generation, "Generation of the Virtual Machine. Defaults to 2.")
+	// a.Describe(&c.NetworkAdapters, "Network adapters to attach to the Virtual Machine.")
+	// a.Describe(&c.HardDrives, "Hard drives to attach to the Virtual Machine.")
+	// a.Describe(&c.HardDrives[0].Path, "Path to the hard drive file.")
+	// a.Describe(&c.HardDrives[0].ControllerType, "Type of controller to use for the hard drive. Defaults to SCSI.")
+	// a.Describe(&c.HardDrives[0].ControllerNumber, "Number of the controller to use for the hard drive. Defaults to 0.")
+	// a.Describe(&c.HardDrives[0].ControllerLocation, "Location of the controller to use for the hard drive. Defaults to 0.")
+	// a.Describe(&c.NetworkAdapters[0].Name, "Name of the network adapter.")
+	// a.Describe(&c.NetworkAdapters[0].SwitchName, "Name of the virtual switch to connect the network adapter to.")
 }
 
 // These are the outputs (or properties) of a Vm resource.

--- a/sdk/dotnet/Machine/Machine.cs
+++ b/sdk/dotnet/Machine/Machine.cs
@@ -98,6 +98,12 @@ namespace Pulumi.Hyperv.Machine
         public Output<string?> Delete { get; private set; } = null!;
 
         /// <summary>
+        /// Generation of the Virtual Machine. Defaults to 2.
+        /// </summary>
+        [Output("generation")]
+        public Output<int?> Generation { get; private set; } = null!;
+
+        /// <summary>
         /// Name of the Virtual Machine
         /// </summary>
         [Output("machineName")]
@@ -195,6 +201,12 @@ namespace Pulumi.Hyperv.Machine
         /// </summary>
         [Input("delete")]
         public Input<string>? Delete { get; set; }
+
+        /// <summary>
+        /// Generation of the Virtual Machine. Defaults to 2.
+        /// </summary>
+        [Input("generation")]
+        public Input<int>? Generation { get; set; }
 
         /// <summary>
         /// Name of the Virtual Machine

--- a/sdk/go/hyperv/machine/machine.go
+++ b/sdk/go/hyperv/machine/machine.go
@@ -92,6 +92,8 @@ type Machine struct {
 	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
 	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrOutput `pulumi:"delete"`
+	// Generation of the Virtual Machine. Defaults to 2.
+	Generation pulumi.IntPtrOutput `pulumi:"generation"`
 	// Name of the Virtual Machine
 	MachineName pulumi.StringOutput `pulumi:"machineName"`
 	// Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.
@@ -163,6 +165,8 @@ type machineArgs struct {
 	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
 	// Command resource from previous create or update steps.
 	Delete *string `pulumi:"delete"`
+	// Generation of the Virtual Machine. Defaults to 2.
+	Generation *int `pulumi:"generation"`
 	// Name of the Virtual Machine
 	MachineName string `pulumi:"machineName"`
 	// Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.
@@ -189,6 +193,8 @@ type MachineArgs struct {
 	// and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
 	// Command resource from previous create or update steps.
 	Delete pulumi.StringPtrInput
+	// Generation of the Virtual Machine. Defaults to 2.
+	Generation pulumi.IntPtrInput
 	// Name of the Virtual Machine
 	MachineName pulumi.StringInput
 	// Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.
@@ -304,6 +310,11 @@ func (o MachineOutput) Create() pulumi.StringPtrOutput {
 // Command resource from previous create or update steps.
 func (o MachineOutput) Delete() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Machine) pulumi.StringPtrOutput { return v.Delete }).(pulumi.StringPtrOutput)
+}
+
+// Generation of the Virtual Machine. Defaults to 2.
+func (o MachineOutput) Generation() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Machine) pulumi.IntPtrOutput { return v.Generation }).(pulumi.IntPtrOutput)
 }
 
 // Name of the Virtual Machine

--- a/sdk/java/src/main/java/com/pulumi/hyperv/machine/Machine.java
+++ b/sdk/java/src/main/java/com/pulumi/hyperv/machine/Machine.java
@@ -123,6 +123,20 @@ public class Machine extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.delete);
     }
     /**
+     * Generation of the Virtual Machine. Defaults to 2.
+     * 
+     */
+    @Export(name="generation", refs={Integer.class}, tree="[0]")
+    private Output</* @Nullable */ Integer> generation;
+
+    /**
+     * @return Generation of the Virtual Machine. Defaults to 2.
+     * 
+     */
+    public Output<Optional<Integer>> generation() {
+        return Codegen.optional(this.generation);
+    }
+    /**
      * Name of the Virtual Machine
      * 
      */

--- a/sdk/java/src/main/java/com/pulumi/hyperv/machine/MachineArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/hyperv/machine/MachineArgs.java
@@ -54,6 +54,21 @@ public final class MachineArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Generation of the Virtual Machine. Defaults to 2.
+     * 
+     */
+    @Import(name="generation")
+    private @Nullable Output<Integer> generation;
+
+    /**
+     * @return Generation of the Virtual Machine. Defaults to 2.
+     * 
+     */
+    public Optional<Output<Integer>> generation() {
+        return Optional.ofNullable(this.generation);
+    }
+
+    /**
      * Name of the Virtual Machine
      * 
      */
@@ -145,6 +160,7 @@ public final class MachineArgs extends com.pulumi.resources.ResourceArgs {
     private MachineArgs(MachineArgs $) {
         this.create = $.create;
         this.delete = $.delete;
+        this.generation = $.generation;
         this.machineName = $.machineName;
         this.memorySize = $.memorySize;
         this.processorCount = $.processorCount;
@@ -214,6 +230,27 @@ public final class MachineArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder delete(String delete) {
             return delete(Output.of(delete));
+        }
+
+        /**
+         * @param generation Generation of the Virtual Machine. Defaults to 2.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder generation(@Nullable Output<Integer> generation) {
+            $.generation = generation;
+            return this;
+        }
+
+        /**
+         * @param generation Generation of the Virtual Machine. Defaults to 2.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder generation(Integer generation) {
+            return generation(Output.of(generation));
         }
 
         /**

--- a/sdk/nodejs/machine/machine.ts
+++ b/sdk/nodejs/machine/machine.ts
@@ -113,6 +113,10 @@ export class Machine extends pulumi.CustomResource {
      */
     public readonly delete!: pulumi.Output<string | undefined>;
     /**
+     * Generation of the Virtual Machine. Defaults to 2.
+     */
+    public readonly generation!: pulumi.Output<number | undefined>;
+    /**
      * Name of the Virtual Machine
      */
     public readonly machineName!: pulumi.Output<string>;
@@ -155,6 +159,7 @@ export class Machine extends pulumi.CustomResource {
             }
             resourceInputs["create"] = args ? args.create : undefined;
             resourceInputs["delete"] = args ? args.delete : undefined;
+            resourceInputs["generation"] = args ? args.generation : undefined;
             resourceInputs["machineName"] = args ? args.machineName : undefined;
             resourceInputs["memorySize"] = args ? args.memorySize : undefined;
             resourceInputs["processorCount"] = args ? args.processorCount : undefined;
@@ -163,6 +168,7 @@ export class Machine extends pulumi.CustomResource {
         } else {
             resourceInputs["create"] = undefined /*out*/;
             resourceInputs["delete"] = undefined /*out*/;
+            resourceInputs["generation"] = undefined /*out*/;
             resourceInputs["machineName"] = undefined /*out*/;
             resourceInputs["memorySize"] = undefined /*out*/;
             resourceInputs["processorCount"] = undefined /*out*/;
@@ -190,6 +196,10 @@ export interface MachineArgs {
      * Command resource from previous create or update steps.
      */
     delete?: pulumi.Input<string>;
+    /**
+     * Generation of the Virtual Machine. Defaults to 2.
+     */
+    generation?: pulumi.Input<number>;
     /**
      * Name of the Virtual Machine
      */

--- a/sdk/python/pulumi_hyperv/machine/machine.py
+++ b/sdk/python/pulumi_hyperv/machine/machine.py
@@ -23,6 +23,7 @@ class MachineArgs:
                  machine_name: pulumi.Input[builtins.str],
                  create: Optional[pulumi.Input[builtins.str]] = None,
                  delete: Optional[pulumi.Input[builtins.str]] = None,
+                 generation: Optional[pulumi.Input[builtins.int]] = None,
                  memory_size: Optional[pulumi.Input[builtins.int]] = None,
                  processor_count: Optional[pulumi.Input[builtins.int]] = None,
                  triggers: Optional[pulumi.Input[Sequence[Any]]] = None,
@@ -34,6 +35,7 @@ class MachineArgs:
         :param pulumi.Input[builtins.str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
                and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
                Command resource from previous create or update steps.
+        :param pulumi.Input[builtins.int] generation: Generation of the Virtual Machine. Defaults to 2.
         :param pulumi.Input[builtins.int] memory_size: Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.
         :param pulumi.Input[builtins.int] processor_count: Number of processors to allocate to the Virtual Machine. Defaults to 1.
         :param pulumi.Input[Sequence[Any]] triggers: Trigger a resource replacement on changes to any of these values. The
@@ -50,6 +52,8 @@ class MachineArgs:
             pulumi.set(__self__, "create", create)
         if delete is not None:
             pulumi.set(__self__, "delete", delete)
+        if generation is not None:
+            pulumi.set(__self__, "generation", generation)
         if memory_size is not None:
             pulumi.set(__self__, "memory_size", memory_size)
         if processor_count is not None:
@@ -96,6 +100,18 @@ class MachineArgs:
     @delete.setter
     def delete(self, value: Optional[pulumi.Input[builtins.str]]):
         pulumi.set(self, "delete", value)
+
+    @property
+    @pulumi.getter
+    def generation(self) -> Optional[pulumi.Input[builtins.int]]:
+        """
+        Generation of the Virtual Machine. Defaults to 2.
+        """
+        return pulumi.get(self, "generation")
+
+    @generation.setter
+    def generation(self, value: Optional[pulumi.Input[builtins.int]]):
+        pulumi.set(self, "generation", value)
 
     @property
     @pulumi.getter(name="memorySize")
@@ -159,6 +175,7 @@ class Machine(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  create: Optional[pulumi.Input[builtins.str]] = None,
                  delete: Optional[pulumi.Input[builtins.str]] = None,
+                 generation: Optional[pulumi.Input[builtins.int]] = None,
                  machine_name: Optional[pulumi.Input[builtins.str]] = None,
                  memory_size: Optional[pulumi.Input[builtins.int]] = None,
                  processor_count: Optional[pulumi.Input[builtins.int]] = None,
@@ -242,6 +259,7 @@ class Machine(pulumi.CustomResource):
         :param pulumi.Input[builtins.str] delete: The command to run on delete. The environment variables PULUMI_COMMAND_STDOUT
                and PULUMI_COMMAND_STDERR are set to the stdout and stderr properties of the
                Command resource from previous create or update steps.
+        :param pulumi.Input[builtins.int] generation: Generation of the Virtual Machine. Defaults to 2.
         :param pulumi.Input[builtins.str] machine_name: Name of the Virtual Machine
         :param pulumi.Input[builtins.int] memory_size: Amount of memory to allocate to the Virtual Machine in MB. Defaults to 1024.
         :param pulumi.Input[builtins.int] processor_count: Number of processors to allocate to the Virtual Machine. Defaults to 1.
@@ -348,6 +366,7 @@ class Machine(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  create: Optional[pulumi.Input[builtins.str]] = None,
                  delete: Optional[pulumi.Input[builtins.str]] = None,
+                 generation: Optional[pulumi.Input[builtins.int]] = None,
                  machine_name: Optional[pulumi.Input[builtins.str]] = None,
                  memory_size: Optional[pulumi.Input[builtins.int]] = None,
                  processor_count: Optional[pulumi.Input[builtins.int]] = None,
@@ -364,6 +383,7 @@ class Machine(pulumi.CustomResource):
 
             __props__.__dict__["create"] = create
             __props__.__dict__["delete"] = delete
+            __props__.__dict__["generation"] = generation
             if machine_name is None and not opts.urn:
                 raise TypeError("Missing required property 'machine_name'")
             __props__.__dict__["machine_name"] = machine_name
@@ -397,6 +417,7 @@ class Machine(pulumi.CustomResource):
 
         __props__.__dict__["create"] = None
         __props__.__dict__["delete"] = None
+        __props__.__dict__["generation"] = None
         __props__.__dict__["machine_name"] = None
         __props__.__dict__["memory_size"] = None
         __props__.__dict__["processor_count"] = None
@@ -421,6 +442,14 @@ class Machine(pulumi.CustomResource):
         Command resource from previous create or update steps.
         """
         return pulumi.get(self, "delete")
+
+    @property
+    @pulumi.getter
+    def generation(self) -> pulumi.Output[Optional[builtins.int]]:
+        """
+        Generation of the Virtual Machine. Defaults to 2.
+        """
+        return pulumi.get(self, "generation")
 
     @property
     @pulumi.getter(name="machineName")


### PR DESCRIPTION
This pull request introduces the concept of "Generation" for Virtual Machines across various files and programming languages within the project. The changes include adding this new property to the schema, input structures, and output structures, and ensuring that it is correctly handled during the creation of Virtual Machines.

### Schema and Input Changes:
* Added the `generation` property to the `schema.json` file, describing it as an integer with a default value of 2. [[1]](diffhunk://#diff-900b143e9b41f285edd03b0f19fa2d9a3de8ffd7757b2676d62e34ce3d9e6a5cR82-R85) [[2]](diffhunk://#diff-900b143e9b41f285edd03b0f19fa2d9a3de8ffd7757b2676d62e34ce3d9e6a5cR124-R127)
* Updated the `MachineInputs` struct in `machine.go` to include the `generation` property, and added corresponding annotations.
* Modified the `MachineArgs` classes in the .NET, Go, Java, Node.js, and Python SDKs to include the `generation` property. [[1]](diffhunk://#diff-31b64a67a5295b3666773dd758ad91285c735895bbe54dd7bdf643bb35b7711eR205-R210) [[2]](diffhunk://#diff-5f4122e4274886063079a21402770bebc5b6f2797948e4ff57372a07ce78154bR168-R169) [[3]](diffhunk://#diff-8228b4f15c93e3e50cbeb9c2f8ebb63eb1735ecb46166fd91ea794e989a8c223R56-R70) [[4]](diffhunk://#diff-78c1bd4f4164efa4dbcb2078be864533cd22d310b5421e5698fdb37951a40c17R199-R202) [[5]](diffhunk://#diff-026322d3716e8291b4cc58b24236615713845bd7552fdfb5113254d4e944e0f7R26)

### Output Changes:
* Added the `generation` property to the `Machine` output structures in the .NET, Go, Java, Node.js, and Python SDKs. [[1]](diffhunk://#diff-31b64a67a5295b3666773dd758ad91285c735895bbe54dd7bdf643bb35b7711eR100-R105) [[2]](diffhunk://#diff-5f4122e4274886063079a21402770bebc5b6f2797948e4ff57372a07ce78154bR95-R96) [[3]](diffhunk://#diff-418db6d1f9b1530b3a93f19fdb0af0816412805f9644b05a775382e03e82435bR125-R138) [[4]](diffhunk://#diff-78c1bd4f4164efa4dbcb2078be864533cd22d310b5421e5698fdb37951a40c17R115-R118) [[5]](diffhunk://#diff-026322d3716e8291b4cc58b24236615713845bd7552fdfb5113254d4e944e0f7R104-R115)

### Creation Logic:
* Updated the `Create` function in `machineController.go` to handle the `generation` property, setting the appropriate Hyper-V generation and handling secure boot settings.

These changes ensure that the new `generation` property is fully integrated into the system, allowing users to specify and retrieve the generation of Virtual Machines.